### PR TITLE
option to upload to a DPAN instead of PAUSE

### DIFF
--- a/lib/CPAN/Uploader.pm
+++ b/lib/CPAN/Uploader.pm
@@ -38,6 +38,7 @@ Valid arguments are:
   password   - (required) your CPAN / PAUSE password
   subdir     - the directory (under your home directory) to upload to
   http_proxy - url of the http proxy to use 
+  dpan_url   - the url of a possible DarkPAN to use instead of PAUSE
   debug      - if set to true, spew lots more debugging output
 
 This method attempts to actually upload the named file to the CPAN.  It will
@@ -90,8 +91,10 @@ sub _upload {
   $agent->env_proxy;
   $agent->proxy(http => $self->{http_proxy}) if $self->{http_proxy};
 
+  my $url = $self->{dpan_url} || $PAUSE_ADD_URI;
+
   my $request = POST(
-    $PAUSE_ADD_URI,
+    $url,
     Content_Type => 'form-data',
     Content      => {
       HIDDENNAME                        => $self->{user},


### PR DESCRIPTION
I think i talked about this once before on IRC: It would be great if i could use Dist::Zilla within my company to push stuff at our internal CPAN::Mini::Inject mirror.

The accompanying change makes a plugin for this purpose much more viable (though i might just make a patch for UploadToCPAN later if and when this is up). It simply makes it possible to specify an optional URL in the object creation.
