### PR TITLE
Allow users to have multiple .pause files

### DIFF
--- a/lib/CPAN/Uploader.pm
+++ b/lib/CPAN/Uploader.pm
@@ -185,7 +185,7 @@ sub read_config_file {
     for my $dir ('.', $ENV{HOME}) {
         # Skip if is undef (ie. home is not set) 
         # or if we already have a filename
-        next unless ($dir || $filename);
+        next if (not $dir || $filename);
         my $file = File::Spec->catfile($dir, '.pause');
         $filename = $file if (-e $file and -r _);
     }


### PR DESCRIPTION
I manage distributions in multiple pause accounts on a single machine. It would be nice to have local user settings for a single distribution that override global settings. I have forked and modified cpan-uploader to allow this, making the config reader prefer .pause files in the current directory. 

I'm sorry I haven't been able to test it more thoroughly, but for all my efforts, I was not able to get Dist::Zilla to install (it throws errors based on inheritance hierarchies). 
