### PR TITLE
Use Config::Identity to permit GPG-encrypted credentials

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for CPAN-Uploader
 
 {{$NEXT}}
+          Use Config::Identity to permit GPG-encrypting on-disk credentials (Mike Doherty)
 
 0.103001  2012-03-26 08:32:44 America/New_York
           Small fixes about upload_uri usage (Getty)

--- a/bin/cpan-upload
+++ b/bin/cpan-upload
@@ -28,9 +28,23 @@ username and password.  It should look like this:
   user EXAMPLE
   password your-secret-password
 
+You can GnuPG-encrypt this file if you wish:
+
+    # Follow the prompts, setting your key as the "recipient"
+    # Use ^D once you've finished typing out your authentication information
+    gpg -ea > $HOME/.pause
+    # OR, encrypt a file you already created:
+    gpg -ea $HOME/.pause && mv $HOME/.pause{.asc,}
+
 =head1 SEE ALSO
 
-L<CPAN::Uploader>
+=over 4
+
+=item L<CPAN::Uploader>
+
+=item L<Config::Identity>
+
+=back
 
 =cut
 

--- a/lib/CPAN/Uploader.pm
+++ b/lib/CPAN/Uploader.pm
@@ -42,7 +42,6 @@ raise an exception on error.
 
 =cut
 
-use Data::Dumper;
 sub upload_file {
   my ($self, $file, $arg) = @_;
 
@@ -56,11 +55,12 @@ sub upload_file {
   $self = $self->new($arg) if $arg;
 
   if ($arg->{dry_run}) {
+    require Data::Dumper;
     $self->log("By request, cowardly refusing to do anything at all.");
     $self->log(
       "The following arguments would have been used to upload: \n"
-      . '$self: ' . Dumper($self)
-      . '$file: ' . Dumper($file)
+      . '$self: ' . Data::Dumper::Dumper($self)
+      . '$file: ' . Data::Dumper::Dumper($file)
     );
   } else {
     $self->_upload($file);

--- a/lib/CPAN/Uploader.pm
+++ b/lib/CPAN/Uploader.pm
@@ -190,9 +190,24 @@ sub read_config_file {
     return {} unless -e $filename and -r _;
   }
 
-  require Config::Identity;
-  my %conf = Config::Identity->load($filename);
-  $conf{user} = delete $conf{username} unless $conf{user};
+  my %conf;
+  if ( eval { require Config::Identity } ) {
+    %conf = Config::Identity->load($filename);
+    $conf{user} = delete $conf{username} unless $conf{user};
+  }
+  else { # Process .pause manually
+    open my $pauserc, '<', $filename
+      or die "can't open $filename for reading: $!";
+
+    while (<$pauserc>) {
+      chomp;
+      next unless $_ and $_ !~ /^\s*#/;
+
+      my ($k, $v) = /^\s*(\w+)\s+(.+)$/;
+      Carp::croak "multiple enties for $k" if $conf{$k};
+      $conf{$k} = $v;
+    }
+  }
 
   return \%conf;
 }

--- a/lib/CPAN/Uploader.pm
+++ b/lib/CPAN/Uploader.pm
@@ -190,21 +190,11 @@ sub read_config_file {
     return {} unless -e $filename and -r _;
   }
 
-  # Process .pause
-  open my $pauserc, '<', $filename
-    or die "can't open $filename for reading: $!";
+  require Config::Identity;
+  my %conf = Config::Identity->load($filename);
+  $conf{user} = delete $conf{username} unless $conf{user};
 
-  my %from_file;
-  while (<$pauserc>) {
-    chomp;
-    next unless $_ and $_ !~ /^\s*#/;
-
-    my ($k, $v) = /^\s*(\w+)\s+(.+)$/;
-    Carp::croak "multiple enties for $k" if $from_file{$k};
-    $from_file{$k} = $v;
-  }
-
-  return \%from_file;
+  return \%conf;
 }
 
 =method log


### PR DESCRIPTION
Also, there's no need to load Data::Dumper unless it is a dry run.