### PR TITLE
more reliable and cross-platform-compatible heuristics for finding ~/.pause

### DIFF
--- a/lib/CPAN/Uploader.pm
+++ b/lib/CPAN/Uploader.pm
@@ -18,6 +18,7 @@ use File::Spec;
 use HTTP::Request::Common qw(POST);
 use HTTP::Status;
 use LWP::UserAgent;
+use File::HomeDir;
 
 my $UPLOAD_URI = $ENV{CPAN_UPLOADER_UPLOAD_URI}
               || 'http://pause.perl.org/pause/authenquery';
@@ -184,7 +185,7 @@ sub read_config_file {
   my ($class, $filename) = @_;
 
   unless ($filename) {
-    my $home  = $ENV{HOME} || '.';
+    my $home  = File::HomeDir->my_home || '.';
     $filename = File::Spec->catfile($home, '.pause');
 
     return {} unless -e $filename and -r _;


### PR DESCRIPTION
Currently the heuristic for finding ~ is very thin and doesn't work on all platforms. This patch adds File::HomeDir to guarantee that the appropiate ~ is found on every platform.
