### PR TITLE
fix documentation link to cpan-upload/CONFIGURATION

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for CPAN-Uploader
 
 {{$NEXT}}
+        - fix documentation link to cpan-upload/CONFIGURATION (Kent Fredric)
 
 0.103007  2014-04-04 22:02:22-04:00 America/New_York
         - added "-c" option to cpan-uploader to specify an alternate config

--- a/lib/CPAN/Uploader.pm
+++ b/lib/CPAN/Uploader.pm
@@ -179,7 +179,7 @@ used as configuration for CPAN::Uploader.
 If no filename is given, it looks for F<.pause> in the user's home directory
 (from the env var C<HOME>, or the current directory if C<HOME> isn't set).
 
-See L<cpan_upload/CONFIGURATION> for the config format.
+See L<cpan-upload/CONFIGURATION> for the config format.
 
 =cut
 


### PR DESCRIPTION
Trivial 1 character doc patch.

Current link 404's 
