### PR TITLE
Document use of Config::Identity

### DIFF
--- a/bin/cpan-upload
+++ b/bin/cpan-upload
@@ -30,7 +30,9 @@ username and password.  It should look like this:
   user EXAMPLE
   password your-secret-password
 
-You can GnuPG-encrypt this file if you wish:
+You can GnuPG-encrypt this file if you wish, but you must install
+L<Config::Identity> and configure your gpg-agent as L<Config::Identity>
+currently doesn't prompt for a password at decryption time:
 
     # Follow the prompts, setting your key as the "recipient"
     # Use ^D once you've finished typing out your authentication information

--- a/lib/CPAN/Uploader.pm
+++ b/lib/CPAN/Uploader.pm
@@ -221,6 +221,11 @@ sub read_config_file {
 
     while (<$pauserc>) {
       chomp;
+      if (/BEGIN PGP MESSAGE/ ) {
+        Carp::croak "$filename seems to be encrypted. "
+          . "Maybe you need to install Config::Identity?"
+      }
+
       next unless $_ and $_ !~ /^\s*#/;
 
       my ($k, $v) = /^\s*(\w+)\s+(.+)$/;


### PR DESCRIPTION
Also aborts if file is encrypted and Config::Identity is not installed.
