### PR TITLE
don't try to chop undefined password from input

### DIFF
--- a/bin/cpan-upload
+++ b/bin/cpan-upload
@@ -112,7 +112,9 @@ if (! $arg{password}) {
   local $| = 1;
   print "PAUSE Password: ";
   Term::ReadKey::ReadMode('noecho');
-  chop($arg{password} = <STDIN>);
+  $arg{password} = <STDIN>;
+  chomp $arg{password}
+    if defined $arg{password};
   Term::ReadKey::ReadMode('restore');
   print "\n";
 }


### PR DESCRIPTION
If STDIN is open to /dev/null, the readline for the password may come
back undef.  Avoid a warning by chomping only when the input is defined.