### PR TITLE
Add retry on failure

### DIFF
--- a/bin/cpan-upload
+++ b/bin/cpan-upload
@@ -23,6 +23,8 @@ use Getopt::Long::Descriptive 0.084;
     --ignore-errors    instead of aborting, continue to next file on error
     -c --config        config file to use; defaults to ~/.pause
     --md5              compute MD5 checksums of the files
+    --retries          number of retries to perform on upload failure
+    --retry-delay      number of seconds to wait between retries
 
 =head1 CONFIGURATION
 
@@ -75,6 +77,8 @@ my ($opt, $usage) = describe_options(
   [ "ignore-errors" => "instead of aborting, continue to next file on error" ],
   [ "config|c=s"    => "config file to use; defaults to ~/.pause" ],
   [ "md5"           => "compute MD5 checksums of the files" ],
+  [ "retries=i"     => "number of retries to perform on upload failure" ],
+  [ "retry-delay=i" => "number of seconds to wait between retries" ],
 );
 
 if ($opt->help) {
@@ -105,7 +109,7 @@ if (
 $arg{debug}  = 1 if $opt->verbose;
 $arg{subdir} = $opt->directory if defined $opt->directory;
 
-$arg{ $_ } = $opt->$_ for grep { defined $opt->$_ } qw(dry_run http_proxy);
+$arg{ $_ } = $opt->$_ for grep { defined $opt->$_ } qw(dry_run http_proxy retries retry_delay);
 
 if (! $arg{password}) {
   require Term::ReadKey;


### PR DESCRIPTION
Background: PAUSE server has been giving random 500 errors since a few months
ago, which is annoying when uploading distributions (e.g. with dzil one will
need to repeat the whole 'dzil release' process).

This relatively simple commit adds retry feature into cpan-upload. The CLI
recognizes --retries (number of retries to perform, defaults to 0 which means no
retry) and --retry-delay (number of seconds to wait between retries, defaults to
0).

At the moment all failures (including 401 or 409 errors) are retried. This might
not be desirable.
