### PR TITLE
remove unnecessary use of File::HomeDir

### DIFF
--- a/lib/CPAN/Uploader.pm
+++ b/lib/CPAN/Uploader.pm
@@ -18,7 +18,7 @@ use File::Spec;
 use HTTP::Request::Common qw(POST);
 use HTTP::Status;
 use LWP::UserAgent;
-use File::HomeDir;
+use File::Glob qw( bsd_glob );
 
 my $UPLOAD_URI = $ENV{CPAN_UPLOADER_UPLOAD_URI}
               || 'https://pause.perl.org/pause/authenquery?ACTION=add_uri';
@@ -218,8 +218,7 @@ sub read_config_file {
   my ($class, $filename) = @_;
 
   unless (defined $filename) {
-    my $home  = File::HomeDir->my_home || '.';
-    $filename = File::Spec->catfile($home, '.pause');
+    $filename = bsd_glob('~/.pause');
 
     return {} unless -e $filename and -r _;
   }


### PR DESCRIPTION
This is similar to #25, which removes the prereq `File::HomeDir`, which would be a benefit on platforms like macOS where it installs a lot of useless nonsense.

 - Plus: This version uses `File::Glob` instead of rolling its own.
 - Minus: I don't know if this works with old Windows Perls, but I don't think anyone should be releasing on such old Perls anyway (at least on Windows)
 - Indeterminate: I also looked at using File::HomeDir::Tiny, which would be great, but it apparently does not work on Perls prior to 5.16 which is mostly its reason for existing.